### PR TITLE
feat: Add finnish language translations for admin UI

### DIFF
--- a/packages/core/admin/admin/src/components/Form.tsx
+++ b/packages/core/admin/admin/src/components/Form.tsx
@@ -574,7 +574,7 @@ const reducer = <TFormValues extends FormValues = FormValues>(
         }
 
         const [key] = generateNKeysBetween(
-          currentField.at(position - 1)?.__temp_key__,
+          position > 0 ? currentField.at(position - 1)?.__temp_key__ : null,
           currentField.at(position)?.__temp_key__,
           1
         );
@@ -582,7 +582,10 @@ const reducer = <TFormValues extends FormValues = FormValues>(
         draft.values = setIn(
           state.values,
           action.payload.field,
-          setIn(currentField, position.toString(), { ...action.payload.value, __temp_key__: key })
+          currentField.toSpliced(position, 0, {
+            ...action.payload.value,
+            __temp_key__: key,
+          })
         );
 
         break;

--- a/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/DynamicZone/DynamicComponent.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/DynamicZone/DynamicComponent.tsx
@@ -7,7 +7,6 @@ import {
   Flex,
   Grid,
   IconButton,
-  VisuallyHidden,
   useComposedRefs,
   Menu,
   MenuItem,
@@ -149,14 +148,17 @@ const DynamicComponent = ({
         <Drag />
       </IconButton>
       <Menu.Root>
-        <Menu.Trigger size="S" endIcon={null} paddingLeft={2} paddingRight={2}>
-          <More aria-hidden focusable={false} />
-          <VisuallyHidden tag="span">
-            {formatMessage({
+        <Menu.Trigger size="S" endIcon={null} paddingLeft={0} paddingRight={0}>
+          <IconButton
+            variant="ghost"
+            label={formatMessage({
               id: getTranslation('components.DynamicZone.more-actions'),
               defaultMessage: 'More actions',
             })}
-          </VisuallyHidden>
+            tag="span"
+          >
+            <More aria-hidden focusable={false} />
+          </IconButton>
         </Menu.Trigger>
         <Menu.Content>
           <Menu.SubRoot>

--- a/packages/core/data-transfer/src/strapi/providers/local-destination/__tests__/assets.test.ts
+++ b/packages/core/data-transfer/src/strapi/providers/local-destination/__tests__/assets.test.ts
@@ -37,6 +37,10 @@ const createStrapi = getStrapiFactory({
     query() {
       return {};
     },
+    lifecycles: {
+      enable: jest.fn(),
+      disable: jest.fn(),
+    },
   },
   config: {
     get(service: string) {
@@ -132,6 +136,10 @@ describe('Local Strapi Destination Provider - Get Assets Stream', () => {
           db: {
             transaction,
             query: mockQuery,
+            lifecycles: {
+              enable: jest.fn(),
+              disable: jest.fn(),
+            },
           },
         }),
       strategy: 'restore',

--- a/packages/core/data-transfer/src/strapi/providers/local-destination/__tests__/index.test.ts
+++ b/packages/core/data-transfer/src/strapi/providers/local-destination/__tests__/index.test.ts
@@ -45,7 +45,13 @@ describe('Local Strapi Source Destination', () => {
     test('Should not have a defined Strapi instance if bootstrap has not been called', () => {
       const provider = createLocalStrapiDestinationProvider({
         getStrapi: getStrapiFactory({
-          db: { transaction },
+          db: {
+            transaction,
+            lifecycles: {
+              enable: jest.fn(),
+              disable: jest.fn(),
+            },
+          },
           ...strapiCommonProperties,
         }),
         strategy: 'restore',
@@ -62,7 +68,13 @@ describe('Local Strapi Source Destination', () => {
     test('Should have a defined Strapi instance if bootstrap has been called', async () => {
       const provider = createLocalStrapiDestinationProvider({
         getStrapi: getStrapiFactory({
-          db: { transaction },
+          db: {
+            transaction,
+            lifecycles: {
+              enable: jest.fn(),
+              disable: jest.fn(),
+            },
+          },
           ...strapiCommonProperties,
         }),
         strategy: 'restore',
@@ -82,7 +94,13 @@ describe('Local Strapi Source Destination', () => {
     test('requires strategy to be restore', async () => {
       const restoreProvider = createLocalStrapiDestinationProvider({
         getStrapi: getStrapiFactory({
-          db: { transaction },
+          db: {
+            transaction,
+            lifecycles: {
+              enable: jest.fn(),
+              disable: jest.fn(),
+            },
+          },
           ...strapiCommonProperties,
         }),
         strategy: 'restore',
@@ -99,7 +117,13 @@ describe('Local Strapi Source Destination', () => {
         (async () => {
           const invalidProvider = createLocalStrapiDestinationProvider({
             getStrapi: getStrapiFactory({
-              db: { transaction },
+              db: {
+                transaction,
+                lifecycles: {
+                  enable: jest.fn(),
+                  disable: jest.fn(),
+                },
+              },
             }),
             /* @ts-ignore: disable-next-line */
             strategy: 'foo',
@@ -203,6 +227,10 @@ describe('Local Strapi Source Destination', () => {
               transacting: jest.fn().mockReturnThis(),
             }),
           }),
+          lifecycles: {
+            enable: jest.fn(),
+            disable: jest.fn(),
+          },
         },
         ...strapiCommonProperties,
       })();

--- a/packages/core/data-transfer/src/strapi/providers/local-destination/index.ts
+++ b/packages/core/data-transfer/src/strapi/providers/local-destination/index.ts
@@ -68,7 +68,7 @@ class LocalStrapiDestinationProvider implements IDestinationProvider {
     if (!this.strapi) {
       throw new ProviderInitializationError('Could not access local strapi');
     }
-
+    this.strapi.db.lifecycles.disable();
     this.transaction = utils.transaction.createTransaction(this.strapi);
   }
 
@@ -101,8 +101,9 @@ class LocalStrapiDestinationProvider implements IDestinationProvider {
 
   async close(): Promise<void> {
     const { autoDestroy } = this.options;
+    assertValidStrapi(this.strapi);
     this.transaction?.end();
-
+    this.strapi.db.lifecycles.enable();
     // Basically `!== false` but more deterministic
     if (autoDestroy === undefined || autoDestroy === true) {
       await this.strapi?.destroy();

--- a/packages/core/data-transfer/src/strapi/providers/local-source/__tests__/index.test.ts
+++ b/packages/core/data-transfer/src/strapi/providers/local-source/__tests__/index.test.ts
@@ -11,13 +11,31 @@ import { createLocalStrapiSourceProvider } from '..';
 describe('Local Strapi Source Provider', () => {
   describe('Bootstrap', () => {
     test('Should not have a defined Strapi instance if bootstrap has not been called', () => {
-      const provider = createLocalStrapiSourceProvider({ getStrapi: getStrapiFactory() });
+      const provider = createLocalStrapiSourceProvider({
+        getStrapi: getStrapiFactory({
+          db: {
+            lifecycles: {
+              enable: jest.fn(),
+              disable: jest.fn(),
+            },
+          },
+        }),
+      });
 
       expect(provider.strapi).not.toBeDefined();
     });
 
     test('Should have a defined Strapi instance if bootstrap has been called', async () => {
-      const provider = createLocalStrapiSourceProvider({ getStrapi: getStrapiFactory() });
+      const provider = createLocalStrapiSourceProvider({
+        getStrapi: getStrapiFactory({
+          db: {
+            lifecycles: {
+              enable: jest.fn(),
+              disable: jest.fn(),
+            },
+          },
+        }),
+      });
       await provider.bootstrap();
 
       expect(provider.strapi).toBeDefined();
@@ -29,7 +47,15 @@ describe('Local Strapi Source Provider', () => {
       const destroy = jest.fn();
 
       const provider = createLocalStrapiSourceProvider({
-        getStrapi: getStrapiFactory({ destroy }),
+        getStrapi: getStrapiFactory({
+          destroy,
+          db: {
+            lifecycles: {
+              enable: jest.fn(),
+              disable: jest.fn(),
+            },
+          },
+        }),
       });
 
       await provider.bootstrap();
@@ -42,7 +68,15 @@ describe('Local Strapi Source Provider', () => {
       const destroy = jest.fn();
 
       const provider = createLocalStrapiSourceProvider({
-        getStrapi: getStrapiFactory({ destroy }),
+        getStrapi: getStrapiFactory({
+          destroy,
+          db: {
+            lifecycles: {
+              enable: jest.fn(),
+              disable: jest.fn(),
+            },
+          },
+        }),
         autoDestroy: true,
       });
 
@@ -56,7 +90,15 @@ describe('Local Strapi Source Provider', () => {
       const destroy = jest.fn();
 
       const provider = createLocalStrapiSourceProvider({
-        getStrapi: getStrapiFactory({ destroy }),
+        getStrapi: getStrapiFactory({
+          destroy,
+          db: {
+            lifecycles: {
+              enable: jest.fn(),
+              disable: jest.fn(),
+            },
+          },
+        }),
         autoDestroy: false,
       });
 
@@ -98,6 +140,10 @@ describe('Local Strapi Source Provider', () => {
           contentTypes,
           db: {
             queryBuilder,
+            lifecycles: {
+              enable: jest.fn(),
+              disable: jest.fn(),
+            },
           },
           getModel: jest.fn((uid) => {
             return contentTypes[uid];
@@ -163,6 +209,12 @@ describe('Local Strapi Source Provider', () => {
 
       const provider = createLocalStrapiSourceProvider({
         getStrapi: getStrapiFactory({
+          db: {
+            lifecycles: {
+              enable: jest.fn(),
+              disable: jest.fn(),
+            },
+          },
           contentTypes,
           components,
         }),

--- a/packages/core/data-transfer/src/strapi/providers/local-source/index.ts
+++ b/packages/core/data-transfer/src/strapi/providers/local-source/index.ts
@@ -39,6 +39,7 @@ class LocalStrapiSourceProvider implements ISourceProvider {
   async bootstrap(diagnostics?: IDiagnosticReporter): Promise<void> {
     this.#diagnostics = diagnostics;
     this.strapi = await this.options.getStrapi();
+    this.strapi.db.lifecycles.disable();
   }
 
   #reportInfo(message: string) {
@@ -54,7 +55,8 @@ class LocalStrapiSourceProvider implements ISourceProvider {
 
   async close(): Promise<void> {
     const { autoDestroy } = this.options;
-
+    assertValidStrapi(this.strapi);
+    this.strapi.db.lifecycles.enable();
     // Basically `!== false` but more deterministic
     if (autoDestroy === undefined || autoDestroy === true) {
       await this.strapi?.destroy();

--- a/packages/core/data-transfer/src/strapi/remote/handlers/utils.ts
+++ b/packages/core/data-transfer/src/strapi/remote/handlers/utils.ts
@@ -126,6 +126,8 @@ export const handleWSUpgrade = (wss: WebSocketServer, ctx: Context, callback: WS
     }
 
     disableTimeouts();
+    strapi.db.lifecycles.disable();
+    strapi.log.info('[Data transfer] Disabling lifecycle hooks');
 
     // Create a connection between the client & the server
     wss.emit('connection', client, ctx.req);
@@ -347,6 +349,8 @@ export const handlerControllerFactory =
             cannotRespondHandler(err);
           } finally {
             resetTimeouts();
+            strapi.db.lifecycles.enable();
+            strapi.log.info('[Data transfer] Restoring lifecycle hooks');
           }
         });
         ws.on('error', async (...args) => {

--- a/packages/core/database/src/lifecycles/index.ts
+++ b/packages/core/database/src/lifecycles/index.ts
@@ -20,6 +20,8 @@ export interface LifecycleProvider {
   clear(): void;
   run(action: Action, uid: string, properties: Properties, states?: States): Promise<States>;
   createEvent(action: Action, uid: string, properties: Properties, state: State): Event;
+  disable(): void;
+  enable(): void;
 }
 
 export const createLifecyclesProvider = (db: Database): LifecycleProvider => {
@@ -27,6 +29,8 @@ export const createLifecyclesProvider = (db: Database): LifecycleProvider => {
     subscriberUtils.timestampsLifecyclesSubscriber,
     subscriberUtils.modelsLifecyclesSubscriber,
   ];
+
+  let isLifecycleHooksDisabled = false;
 
   return {
     subscribe(subscriber) {
@@ -42,6 +46,14 @@ export const createLifecyclesProvider = (db: Database): LifecycleProvider => {
 
     clear() {
       subscribers = [];
+    },
+
+    disable() {
+      isLifecycleHooksDisabled = true;
+    },
+
+    enable() {
+      isLifecycleHooksDisabled = false;
     },
 
     createEvent(action, uid, properties, state): Event {
@@ -62,6 +74,7 @@ export const createLifecyclesProvider = (db: Database): LifecycleProvider => {
      * @param {Map<any, any>} states
      */
     async run(action, uid, properties, states = new Map()) {
+      if (isLifecycleHooksDisabled) return states;
       for (let i = 0; i < subscribers.length; i += 1) {
         const subscriber = subscribers[i];
         if (typeof subscriber === 'function') {


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Adds finnish translations for the admin ui.

### Why is it needed?

Currently Strapi is lacking finnish language support for the admin ui.

### How to test it?

This can be tested by adding 'fi' to the locales array in the example application app.tsx and selecting 'Suomi' dislay language from the admin UI profile settings.

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
